### PR TITLE
Make Query Validation Explicit to User

### DIFF
--- a/packages/tesseract-explorer/src/components/ButtonExecuteQuery.jsx
+++ b/packages/tesseract-explorer/src/components/ButtonExecuteQuery.jsx
@@ -1,12 +1,13 @@
-import {Button, ButtonGroup, Classes, Intent} from "@blueprintjs/core";
+import {ButtonGroup, Classes, Intent, Position} from "@blueprintjs/core";
 import React from "react";
 import {useDispatch, useSelector} from "react-redux";
 import {useTranslation} from "../hooks/translation";
 import {willExecuteQuery} from "../middleware/olapActions";
 import {doSetLoadingState} from "../state/loading/actions";
+import {selectValidQueryStatus} from "../state/params/selectors";
 import {doUpdateEndpoint} from "../state/server/actions";
 import {selectServerEndpoint, selectServerSoftware} from "../state/server/selectors";
-import {ButtonTooltip} from "./Tooltips";
+import {AnchorButtonTooltip, ButtonTooltip} from "./Tooltips";
 
 /** @type {React.FC<{}>} */
 export const ButtonExecuteQuery = () => {
@@ -17,13 +18,21 @@ export const ButtonExecuteQuery = () => {
   const endpoint = useSelector(selectServerEndpoint);
   const software = useSelector(selectServerSoftware);
 
+  const {isValid, error} = useSelector(selectValidQueryStatus);
+
+  const errorText = error && t(error) !== error ? t(error) : "";
+
   return (
     <ButtonGroup className="query-actions p-3" fill>
-      <Button
+      <AnchorButtonTooltip
         fill={true}
+        disabled={!isValid}
         icon="database"
         intent={Intent.PRIMARY}
         text={t("params.action_execute")}
+        tooltipText={errorText}
+        tooltipIntent={Intent.DANGER}
+        tooltipPosition={Position.TOP}
         onClick={() => {
           dispatch(doSetLoadingState("REQUEST"));
           dispatch(willExecuteQuery()).then(() => {

--- a/packages/tesseract-explorer/src/components/Tooltips.jsx
+++ b/packages/tesseract-explorer/src/components/Tooltips.jsx
@@ -1,4 +1,4 @@
-import {Tooltip, Button, Icon} from "@blueprintjs/core";
+import {AnchorButton, Button, Icon, Tooltip} from "@blueprintjs/core";
 import {createElement} from "react";
 
 /**
@@ -34,9 +34,20 @@ export const IconTooltip = props => {
 export const ButtonTooltip = props => {
   const {tooltipIntent, tooltipPosition, tooltipText, ...restProps} = props;
   return createElement(TooltipWrapper, {
-    tooltipClassName: "button-tooltip",
+    tooltipClassName: `button-tooltip ${props.fill ? "button-tooltip-fill" : ""}`,
     tooltipIntent,
     tooltipPosition,
     tooltipText
   }, createElement(Button, restProps));
+};
+
+/** @type {React.FC<BlueprintCore.AnchorButtonProps & TooltipProps>} */
+export const AnchorButtonTooltip = props => {
+  const {tooltipIntent, tooltipPosition, tooltipText, ...restProps} = props;
+  return createElement(TooltipWrapper, {
+    tooltipClassName: `button-tooltip ${props.fill ? "button-tooltip-fill" : ""}`,
+    tooltipIntent,
+    tooltipPosition,
+    tooltipText
+  }, createElement(AnchorButton, restProps));
 };

--- a/packages/tesseract-explorer/src/hooks/translation.js
+++ b/packages/tesseract-explorer/src/hooks/translation.js
@@ -112,6 +112,9 @@ export const defaultTranslation = {
   queries: {
     action_create: "New query",
     action_parse: "Query from URL",
+    error_not_query: "Please construct a valid query",
+    error_no_drilldowns: "You must add at least one drilldown.",
+    error_no_measures: "You must add at least one measure.",
     column_title: "Queries",
     unset_parameters: "No parameters set",
   },
@@ -139,7 +142,7 @@ export const defaultTranslation = {
     search_placeholder: "Filter (regex enabled)",
     select_all: "Select all",
     unselect_all: "Unselect all",
-  },
+  }
 };
 
 export const {

--- a/packages/tesseract-explorer/src/state/params/selectors.js
+++ b/packages/tesseract-explorer/src/state/params/selectors.js
@@ -1,5 +1,6 @@
 import ISO6391 from "iso-639-1";
 import {createSelector} from "reselect";
+import {isValidQueryVerbose} from "../../utils/validation";
 import {getKeys, getValues} from "../helpers";
 import {selectCurrentQueryItem} from "../queries/selectors";
 import {selectServerState} from "../server/selectors";
@@ -85,4 +86,9 @@ export const selectPaginationParams = createSelector(
 export const selectSortingParams = createSelector(
   selectCurrentQueryParams,
   params => ({sortKey: params.sortKey || "", sortDir: params.sortDir})
+);
+
+export const selectValidQueryStatus = createSelector(
+  selectCurrentQueryParams,
+  params => isValidQueryVerbose(params)
 );

--- a/packages/tesseract-explorer/src/style.css
+++ b/packages/tesseract-explorer/src/style.css
@@ -14,6 +14,10 @@
   box-sizing: border-box;
 }
 
+.button-tooltip-fill {
+  width: 100%;
+}
+
 /* WRAPPER */
 .explorer-wrapper {
   height: 100%;

--- a/packages/tesseract-explorer/src/utils/validation.js
+++ b/packages/tesseract-explorer/src/utils/validation.js
@@ -51,15 +51,46 @@ export function isQuery(query) {
 }
 
 /**
- * @param {any} query
- * @returns {query is QueryParams}
+ * List of conditions that make a Query valid.
+ */
+const validQueryConditions = [
+  {
+    condition: isQuery,
+    error: "queries.error_not_query"
+  },
+  {
+    condition: query => Object.values(query.measures).reduce(activeItemCounter, 0) > 0,
+    error: "queries.error_no_measures"
+  },
+  {
+    condition: query => Object.values(query.drilldowns).reduce(activeItemCounter, 0) > 0,
+    error: "queries.error_no_drilldowns"
+  }
+];
+
+/**
+ * Validates whether the provided object is a valid Query object that can be used to make a request.
+ * @param {any} query - query to validate
+ * @returns {boolean}
  */
 export function isValidQuery(query) {
-  return (
-    isQuery(query) &&
-    Object.values(query.drilldowns).reduce(activeItemCounter, 0) > 0 &&
-    Object.values(query.measures).reduce(activeItemCounter, 0) > 0
-  );
+  return validQueryConditions.every(queryCondition => queryCondition.condition(query));
+}
+
+/**
+ * Validates whether the provided object is a valid Query object that can be used to make a request.
+ * Also returns an error message of the first failed condition.
+ * @param {any} query - query to validate
+ * @returns {{isValid: boolean, error: undefined | string}}
+ */
+export function isValidQueryVerbose(query) {
+  let error;
+  const allConditionsPass = validQueryConditions.every(queryCondition => {
+    const passed = queryCondition.condition(query);
+    if (!passed) error = queryCondition.error;
+    return passed;
+  });
+  return {isValid: allConditionsPass, error};
 }
 
 /** @param {TessExpl.Struct.CutItem} item */


### PR DESCRIPTION
closes #37 

Disables the Execute Query button based on the whether the currently built query is valid or not. Adds messages to each validation condition so that the user is notified (via a tooltip on the Execute Query button) of the exact reason why a query can not be executed.

Changes in this PR include:
- adding of a new `AnchorButtonTooltip` that allows for the tracking of hover behaviors even when the button is disabled
- refactor query validation to refer to an array of conditions with (localizable) error messages
- add a verbose version of validating the query that returns the first error message encountered
- adds CSS class for buttons with tooltips that need to be full width