### PR TITLE
Pass Through Vizbuilder Props

### DIFF
--- a/example/src/index.jsx
+++ b/example/src/index.jsx
@@ -13,6 +13,18 @@ import {
   TableView
 } from "@datawheel/tesseract-explorer";
 
+import Vizbuilder from "@datawheel/tesseract-vizbuilder";
+
+const VizbuilderPanel = props =>
+  <Vizbuilder
+    cube={props.cube}
+    result={props.result}
+    params={props.params}
+    allowedChartTypes={["barchart", "barchartyear", "lineplot", "stacked", "treemap", "geomap", "donut"]}
+    downloadFormats={["svg", "png"]}
+    showConfidenceInt={false}
+  />;
+
 const composeEnhancers =
   typeof window === "object" && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
     ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
@@ -28,7 +40,8 @@ FocusStyleManager.onlyShowFocusOnTabs();
 const PANELS = {
   "Data Table": TableView,
   "Pivot Table": PivotView,
-  "Raw response": DebugView
+  "Raw response": DebugView,
+  "Vizbuilder": VizbuilderPanel
 };
 
 ReactDOM.render(

--- a/packages/vizbuilder/package.json
+++ b/packages/vizbuilder/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "index.d.ts",
-  "style": "dist/view-vizbuilder.css",
+  "style": "dist/vizbuilder.css",
   "scripts": {
     "build": "rollup --config ../../rollup.config.js --environment NODE_ENV:production",
     "watch": "rollup --config ../../rollup.config.js --environment NODE_ENV:development --watch"
@@ -24,11 +24,11 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Datawheel/tesseract-ui.git",
-    "directory": "packages/view-vizbuilder"
+    "directory": "packages/vizbuilder"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "^7.13.10",
-    "@datawheel/vizbuilder": "^0.2.0"
+    "@datawheel/vizbuilder": "^0.2.7"
   },
   "devDependencies": {
     "@datawheel/tesseract-explorer": "workspace:^1.0.0-alpha.10",

--- a/packages/vizbuilder/src/VizbuilderView.jsx
+++ b/packages/vizbuilder/src/VizbuilderView.jsx
@@ -14,7 +14,7 @@ function mapActives(dict, mapFn) {
 
 /** @type {React.FC<import("..").VizbuilderViewProps & {version: string}>} */
 export const VizbuilderView = props => {
-  const {params, result, formatters = {}} = props;
+  const {params, result, formatters = {}, ...otherProps} = props;
 
   /** @type {VizBldr.QueryResult} */
   const queries = useMemo(() => {
@@ -55,17 +55,9 @@ export const VizbuilderView = props => {
   }, [result.data, params]);
 
   return createElement(Vizbuilder, {
-    allowedChartTypes: props.allowedChartTypes,
     className: "vizbuilder-view",
-    datacap: props.datacap,
-    defaultLocale: props.defaultLocale,
-    measureConfig: props.measureConfig,
-    onPeriodChange: props.onPeriodChange,
     queries,
-    showConfidenceInt: props.showConfidenceInt,
-    topojsonConfig: props.topojsonConfig,
-    translations: props.translations,
-    userConfig: props.userConfig
+    ...otherProps
   });
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,13 +167,13 @@ importers:
     specifiers:
       '@babel/runtime-corejs3': ^7.13.10
       '@datawheel/tesseract-explorer': workspace:^1.0.0-alpha.10
-      '@datawheel/vizbuilder': ^0.2.0
+      '@datawheel/vizbuilder': ^0.2.7
       react: ^16.14.0
       react-dom: ^16.14.0
       rollup: ^2.45.2
     dependencies:
       '@babel/runtime-corejs3': 7.14.0
-      '@datawheel/vizbuilder': 0.2.0
+      '@datawheel/vizbuilder': 0.2.7_react-dom@16.14.0+react@16.14.0
     devDependencies:
       '@datawheel/tesseract-explorer': link:../tesseract-explorer
       react: 16.14.0
@@ -1511,13 +1511,18 @@ packages:
       react: 16.14.0
     dev: false
 
-  /@datawheel/vizbuilder/0.2.0:
-    resolution: {integrity: sha512-F5d/4m2czmcWoMWIpA5hXr9xL8/qmPFL5fji+BLxOWxgv9Ks5mYybEoOJ1kFaS0G+KLijNeLeLB6+sTLlAGP9w==}
+  /@datawheel/vizbuilder/0.2.7_react-dom@16.14.0+react@16.14.0:
+    resolution: {integrity: sha512-ptyrAwrc3eMKmpVYtBvqx+UTY/pWzWlEVuQ/ZmBdS3yc+r1PRNcB9wzrIlgBICw3BTEwldKrlwN/tbXIzGVBkQ==}
+    peerDependencies:
+      react: ^16.12.0
+      react-dom: ^16.12.0
     dependencies:
       '@babel/runtime-corejs3': 7.14.0
       '@datawheel/olap-client': 2.0.0-beta.3
+      '@datawheel/use-translation': 0.1.2_react@16.14.0
       classnames: 2.3.1
       d3plus-common: 1.0.3
+      d3plus-export: 1.0.0
       d3plus-format: 1.0.0
       d3plus-react: 1.0.0_react@16.14.0
       lodash: 4.17.21


### PR DESCRIPTION
This change is in response to a bug where a certain prop (`downloadFormats`) required by the core `Vizbuilder` component was not being passed down from the `VizbuilderView` component that wraps the core Vizbuilder component and integrates it with Tesseract Explorer. All props for the core `Vizbuilder` component were being passed manually -- this created a situation where a prop was not being passed down and it blocked essential functionality.

Solution: Non-Tesseract Explorer props (like the query state) are now collected and passed down to the `Vizbuilder` component _in a generalized manner_ so that the `VizbuilderView` is more maintainable and does not need to be updated every time a prop is added to  the core`Vizbuilder` component.

Other changes:
- updated example app to include Vizbuilder panel for easier debugging
- updated Vizbuilder dependency version (to include recent bug fixes and improve stability)
- changed some legacy (?) folder name `view-vizbuilder` to the current dir name, `vizbuilder`