### PR TITLE
Override Default Splash Screen

### DIFF
--- a/packages/tesseract-explorer/index.d.ts
+++ b/packages/tesseract-explorer/index.d.ts
@@ -33,6 +33,12 @@ declare namespace TessExpl {
     className?: string;
 
     /**
+     * A component that is rendered to display the default "splash screen," the screen
+     * that is shown in the results panel when there is no query or a query has been dirtied.
+     */
+    DefaultSplash?: React.FunctionComponent | React.ComponentClass;
+
+    /**
      * Enables multiple query mode.
      * This adds a column where the user can quickly switch between queries,
      * like tabs in a browser.

--- a/packages/tesseract-explorer/src/components/Explorer.jsx
+++ b/packages/tesseract-explorer/src/components/Explorer.jsx
@@ -49,6 +49,7 @@ export const ExplorerComponent = props => {
           <ExplorerResults
             className="explorer-results"
             panels={props.panels || defaultProps.panels}
+            DefaultSplash={props.DefaultSplash}
             transientIcon={props.transientIcon ?? defaultProps.transientIcon}
           />
         </div>

--- a/packages/tesseract-explorer/src/components/ExplorerResults.jsx
+++ b/packages/tesseract-explorer/src/components/ExplorerResults.jsx
@@ -11,13 +11,14 @@ import {selectServerState} from "../state/server/selectors";
 /**
  * @typedef OwnProps
  * @property {string} [className]
+ * @property {any} [DefaultSplash]
  * @property {BlueprintCore.IconName | React.ReactElement | React.ReactFragment | false} transientIcon
  * @property {Record<string, React.FunctionComponent | React.ComponentClass>} panels
  */
 
 /** @type {React.FC<OwnProps>} */
 export const ExplorerResults = props => {
-  const {panels, transientIcon} = props;
+  const {DefaultSplash, panels, transientIcon} = props;
   const [currentTab, setCurrentTab] = useState(Object.keys(panels)[0]);
 
   const serverStatus = useSelector(selectServerState);
@@ -70,6 +71,7 @@ export const ExplorerResults = props => {
 
   if (isDirtyQuery) {
     return (
+      DefaultSplash && <DefaultSplash/> ||
       <NonIdealState
         className={classNames("initial-view dirty", props.className)}
         icon={transientIcon}


### PR DESCRIPTION
Adds functionality for optionally passing a component in as a prop to the top-level `Explorer` component that is displayed when a query has not been made (like on first load) or if a query has been dirtied.