### PR TITLE
Sort drilldowns feature

### DIFF
--- a/example/src/index.jsx
+++ b/example/src/index.jsx
@@ -51,6 +51,7 @@ ReactDOM.render(
       formatters={{Sheep: n => `🐑 ${n.toFixed()}`}}
       multiquery
       uiLocale="pt"
+      locale={['pt','en']}
       panels={PANELS}
     />
   </Provider>,

--- a/packages/cube-audit/README.md
+++ b/packages/cube-audit/README.md
@@ -46,6 +46,12 @@ You might find a cube that has one or many levels with thousands or millions of 
 | dataset_link | Web address for the dataset (will turn `dataset_name` display into an anchor link). |
 | dataset_description | Description of the dataset (typically a few short sentences). |
 
+### Dimensions, Hierarchies & Levels
+
+| Annotation Name | Description |
+| --- | --- |
+| order | Optional. Allows to sort the elements in the selection menues to add entities. |
+
 ### Measures
 
 | Annotation Name | Description |

--- a/packages/tesseract-explorer/src/components/MenuDimension.jsx
+++ b/packages/tesseract-explorer/src/components/MenuDimension.jsx
@@ -22,6 +22,8 @@ export const DimensionMenu = props => {
   const dimensions = useSelector(selectOlapDimensionItems) || [];
   const locale = useSelector(selectLocale);
 
+  console.log(dimensions);
+
   const options = useMemo(() => dimensions.map(dim =>
     <DimensionMenuItem
       dimension={dim}

--- a/packages/tesseract-explorer/src/components/MenuDimension.jsx
+++ b/packages/tesseract-explorer/src/components/MenuDimension.jsx
@@ -22,8 +22,6 @@ export const DimensionMenu = props => {
   const dimensions = useSelector(selectOlapDimensionItems) || [];
   const locale = useSelector(selectLocale);
 
-  console.log(dimensions);
-
   const options = useMemo(() => dimensions.map(dim =>
     <DimensionMenuItem
       dimension={dim}

--- a/packages/tesseract-explorer/src/state/helpers.js
+++ b/packages/tesseract-explorer/src/state/helpers.js
@@ -53,3 +53,14 @@ export function getKeys(map) {
 export function getValues(map) {
   return Object.values(map);
 }
+
+/**
+ * Parse and convert order value from an schema object
+ * (that supports annotations) to an integer value.
+ * If null return a big number.
+ * @param {any} schemaObject
+ */
+export function getOrderValue(schemaObject) {
+  const orderValue = schemaObject.annotations?.order;
+  return orderValue && !isNaN(orderValue) ? parseInt(orderValue, 10) : 99
+}

--- a/packages/tesseract-explorer/src/state/helpers.js
+++ b/packages/tesseract-explorer/src/state/helpers.js
@@ -57,7 +57,7 @@ export function getValues(map) {
 /**
  * Parse and convert order value from an schema object
  * (that supports annotations) to an integer value.
- * If null return a big number.
+ * If null return a big number: 99
  * @param {any} schemaObject
  */
 export function getOrderValue(schemaObject) {

--- a/packages/tesseract-explorer/src/state/selectors.js
+++ b/packages/tesseract-explorer/src/state/selectors.js
@@ -2,6 +2,7 @@ import {createSelector} from "reselect";
 import {triad, tuple} from "../utils/array";
 import {selectCubeName} from "./params/selectors";
 import {selectOlapCubeMap} from "./server/selectors";
+import {getOrderValue} from "./helpers";
 
 /**
  * @returns {OlapClient.PlainCube}
@@ -35,11 +36,24 @@ export const selectOlapDimensionItems = createSelector(
   cube => cube
     ? cube.dimensions
       .map(dim => ({
-        item: dim,
-        count: dim.hierarchies.reduce((acc, hie) => acc + hie.levels.length, 0),
-        alpha: dim.hierarchies.reduce((acc, hie) => acc.concat(hie.name, "-"), "")
-      }))
+          item: {
+            ...dim,
+            hierarchies: dim.hierarchies.map(hierarchy => {
+              hierarchy.levels.sort((a, b) =>
+                getOrderValue(a) - getOrderValue(b)
+              );
+              return hierarchy;
+            })
+            .sort((a, b) =>
+              getOrderValue(a) - getOrderValue(b)
+            )
+          },
+          count: dim.hierarchies.reduce((acc, hie) => acc + hie.levels.length, 0),
+          alpha: dim.hierarchies.reduce((acc, hie) => acc.concat(hie.name, "-"), "")
+        }
+      ))
       .sort((a, b) =>
+        getOrderValue(a) - getOrderValue(b) ||
         b.count - a.count ||
         a.alpha.localeCompare(b.alpha)
       )

--- a/packages/tesseract-explorer/src/state/selectors.js
+++ b/packages/tesseract-explorer/src/state/selectors.js
@@ -53,7 +53,7 @@ export const selectOlapDimensionItems = createSelector(
         }
       ))
       .sort((a, b) =>
-        getOrderValue(a) - getOrderValue(b) ||
+        getOrderValue(a.item) - getOrderValue(b.item) ||
         b.count - a.count ||
         a.alpha.localeCompare(b.alpha)
       )


### PR DESCRIPTION
You can test using the sebrae DEV schema:
```
export OLAPPROXY_TARGET='https://dev.sebrae.api.datawheel.us/tesseract/'
```

that has the new tag at dimension level:
`<Annotation name="order">1</Annotation>` 

Is there a place for all the available tags for annotations documented?