### PR TITLE
Feature limit and preview mode

### DIFF
--- a/example/src/index.jsx
+++ b/example/src/index.jsx
@@ -51,7 +51,7 @@ ReactDOM.render(
       formatters={{Sheep: n => `🐑 ${n.toFixed()}`}}
       multiquery
       uiLocale="pt"
-      previewLimit={100}
+      previewLimit={75}
       locale={['pt','en']}
       panels={PANELS}
     />

--- a/example/src/index.jsx
+++ b/example/src/index.jsx
@@ -51,6 +51,7 @@ ReactDOM.render(
       formatters={{Sheep: n => `🐑 ${n.toFixed()}`}}
       multiquery
       uiLocale="pt"
+      previewLimit={100}
       locale={['pt','en']}
       panels={PANELS}
     />

--- a/packages/tesseract-explorer/README.md
+++ b/packages/tesseract-explorer/README.md
@@ -169,9 +169,9 @@ The key used to select a formatter comes from the `format_template` annotation, 
 * If any of these are present, numbers are presented in Decimal format.
 
 ## Preview queries feature
-In order to reduce the amount of big queries we implemented the `previewLimit` property. It allows the user ... TO-DO
+In order to reduce the amount of big queries/responses we implemented the `previewLimit` property. Default value is `50`. In this initial version, it allows the user fine tune the query receiving small payloads truncating the amout of records with `limit` value until the user explicity enable the `Full results options`.
 
 ## License
 
-©2018-2021 [Datawheel, LLC](https://datawheel.us/)
+©2018-2022 [Datawheel, LLC](https://datawheel.us/)
 This project is made available under the [MIT License](./LICENSE).

--- a/packages/tesseract-explorer/README.md
+++ b/packages/tesseract-explorer/README.md
@@ -130,11 +130,11 @@ function PageComponent(props) {
 }
 ```
 
-* `translations` must be an object where the keys are the locale codes you intend to make available in the app, and the values are dictionaries that complies with the labels [defined in this file](./src/utils/localization.js).  
+* `translations` must be an object where the keys are the locale codes you intend to make available in the app, and the values are dictionaries that complies with the labels [defined in this file](./src/utils/localization.js).
   This object is also exported by this package so you can check it yourself.
 * `uiLocale`, which is not related to the `locale` property mentioned in the earlier section, must be a string matching one of the keys defined in the `translations` property.
 
-When used, both properties are required.  
+When used, both properties are required.
 The locale keys used not necesarily must be ISO 639 codes; any string can do, but must match on both properties.
 
 Some translation labels do interpolation of values when used. These are optional, but encouraged, and some can have additional values available:
@@ -163,12 +163,15 @@ const formatterIndex = useMemo(() => ({
 ```
 
 The app comes with a limited list of default ones: `Decimal` (1234.567), `Milliards` (1,234.567), `Dollars` ($1,234.57), and `Human` (1.23k).
-The key used to select a formatter comes from the `format_template` annotation, and if not present, the `units_of_measurement` annotation in the measure data.  
+The key used to select a formatter comes from the `format_template` annotation, and if not present, the `units_of_measurement` annotation in the measure data.
 * If the measure contains the `format_template` annotation, it is used to create a custom formatter on runtime. [Check the documentation](https://github.com/d3plus/d3plus-format#readme) for details on how to build and customize a template.
-* If the `units_of_measurement` set is an official ISO 4217 currency code (three letters in caps), it will be parsed into a currency formatter using the browser's [`Intl.NumberFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) constructor. Otherwise, the key is looked in the `formatters` property object and in the default formatters list.  
+* If the `units_of_measurement` set is an official ISO 4217 currency code (three letters in caps), it will be parsed into a currency formatter using the browser's [`Intl.NumberFormat`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) constructor. Otherwise, the key is looked in the `formatters` property object and in the default formatters list.
 * If any of these are present, numbers are presented in Decimal format.
+
+## Preview queries feature
+In order to reduce the amount of big queries we implemented the `previewLimit` property. It allows the user ... TO-DO
 
 ## License
 
-©2018-2021 [Datawheel, LLC](https://datawheel.us/)  
+©2018-2021 [Datawheel, LLC](https://datawheel.us/)
 This project is made available under the [MIT License](./LICENSE).

--- a/packages/tesseract-explorer/index.d.ts
+++ b/packages/tesseract-explorer/index.d.ts
@@ -79,6 +79,12 @@ declare namespace TessExpl {
      * The default locale to use in the Explorer component UI.
      */
     uiLocale?: TranslationProviderProps["defaultLocale"];
+
+    /**
+     * The default limit for preview queries. 0 (or null) means that preview feature will be disabled.
+     * Default 0
+     */
+    previewLimit?: Number | 0;
   }
 
   interface ViewProps {

--- a/packages/tesseract-explorer/index.d.ts
+++ b/packages/tesseract-explorer/index.d.ts
@@ -81,10 +81,10 @@ declare namespace TessExpl {
     uiLocale?: TranslationProviderProps["defaultLocale"];
 
     /**
-     * The default limit for preview queries. 0 (or null) means that preview feature will be disabled.
-     * Default 0
+     * The default limit for preview queries.
+     * Default 100
      */
-    previewLimit?: Number | 0;
+    previewLimit?: Number | 50;
   }
 
   interface ViewProps {

--- a/packages/tesseract-explorer/src/components/AreaOptions.jsx
+++ b/packages/tesseract-explorer/src/components/AreaOptions.jsx
@@ -1,8 +1,9 @@
 import {Checkbox} from "@blueprintjs/core";
 import React from "react";
 import {useDispatch, useSelector} from "react-redux";
+import {useSettings} from "../hooks/settings";
 import {useTranslation} from "../hooks/translation";
-import {doBooleanToggle} from "../state/params/actions";
+import {doBooleanToggle, doPaginationUpdate} from "../state/params/actions";
 import {selectBooleans} from "../state/params/selectors";
 import {selectServerBooleansEnabled} from "../state/server/selectors";
 import {LayoutParamsArea} from "./LayoutParamsArea";
@@ -19,6 +20,7 @@ export const AreaOptions = props => {
   const dispatch = useDispatch();
 
   const {translate: t} = useTranslation();
+  const {previewLimit} = useSettings();
 
   const booleans = useSelector(selectBooleans);
   const enabledBooleans = useSelector(selectServerBooleansEnabled);
@@ -38,6 +40,10 @@ export const AreaOptions = props => {
           checked={booleans[key] || false}
           onChange={() => {
             dispatch(doBooleanToggle(key));
+            // Update pagination value if full results
+            if (key === "full_results"){
+              dispatch(doPaginationUpdate(!booleans[key]?0:previewLimit, 0));
+            }
           }}
         />
       )}

--- a/packages/tesseract-explorer/src/components/Explorer.jsx
+++ b/packages/tesseract-explorer/src/components/Explorer.jsx
@@ -33,8 +33,10 @@ export const ExplorerComponent = props => {
 
   const serverState = useSelector(selectServerState);
 
+  console.log(serverState);
+
   return (
-    <SettingsProvider formatters={props.formatters}>
+    <SettingsProvider formatters={props.formatters} previewLimit={props.previewLimit}>
       <TranslationProvider defaultLocale={props.uiLocale} translations={props.translations}>
         <div className={clsx("explorer-wrapper", props.className)}>
           <LoadingOverlay className="explorer-loading" />

--- a/packages/tesseract-explorer/src/components/Explorer.jsx
+++ b/packages/tesseract-explorer/src/components/Explorer.jsx
@@ -29,14 +29,15 @@ const defaultProps = {
 
 /** @type {React.FC<TessExpl.ExplorerProps>} */
 export const ExplorerComponent = props => {
-  const isSetupDone = useSetup(props.src, props.locale || defaultProps.locale);
+
+  const previewLimit = props.previewLimit || 50;
+
+  const isSetupDone = useSetup(props.src, props.locale || defaultProps.locale, previewLimit);
 
   const serverState = useSelector(selectServerState);
 
-  console.log(serverState);
-
   return (
-    <SettingsProvider formatters={props.formatters} previewLimit={props.previewLimit}>
+    <SettingsProvider formatters={props.formatters} previewLimit={previewLimit}>
       <TranslationProvider defaultLocale={props.uiLocale} translations={props.translations}>
         <div className={clsx("explorer-wrapper", props.className)}>
           <LoadingOverlay className="explorer-loading" />

--- a/packages/tesseract-explorer/src/components/ExplorerResults.jsx
+++ b/packages/tesseract-explorer/src/components/ExplorerResults.jsx
@@ -1,12 +1,13 @@
 import {Icon, NonIdealState, Tab, Tabs} from "@blueprintjs/core";
 import classNames from "classnames";
 import React, {Suspense, useState} from "react";
-import {useSelector} from "react-redux";
+import {useDispatch, useSelector} from "react-redux";
 import {useTranslation} from "../hooks/translation";
 import {selectLoadingState} from "../state/loading/selectors";
 import {selectCurrentQueryItem} from "../state/queries/selectors";
 import {selectOlapCube} from "../state/selectors";
 import {selectServerState} from "../state/server/selectors";
+import {doBooleanToggle} from "../state/params/actions";
 
 /**
  * @typedef OwnProps
@@ -21,6 +22,7 @@ export const ExplorerResults = props => {
   const {DefaultSplash, panels, transientIcon} = props;
   const [currentTab, setCurrentTab] = useState(() => Object.keys(panels)[0]);
 
+  const dispatch = useDispatch();
   const serverStatus = useSelector(selectServerState);
   const {loading: isLoading} = useSelector(selectLoadingState);
   const cube = useSelector(selectOlapCube);
@@ -29,6 +31,8 @@ export const ExplorerResults = props => {
   const {online: isServerOnline, url: serverUrl} = serverStatus;
   const {isDirty: isDirtyQuery, params, result} = queryItem;
   const {data, error} = result;
+
+  const fullResults = Boolean(params.booleans.full_results);
 
   const {translate: t} = useTranslation();
 
@@ -102,6 +106,7 @@ export const ExplorerResults = props => {
         {Object.keys(panels).map(key => <Tab id={key} key={key} title={t(key)} />)}
         <Tabs.Expander />
         <h2 className="token">{t("results.count_rows", {n: data.length})}</h2>
+        <h2 className="token" onClick={() => dispatch(doBooleanToggle("full_results"))}>{fullResults?"Get preview":"Get full"}</h2>
       </Tabs>
       <div className={`wrapper ${props.className}-content`}>
         <Suspense fallback={typeof transientIcon === "string" ? <Icon name={transientIcon} /> : transientIcon}>

--- a/packages/tesseract-explorer/src/components/ExplorerResults.jsx
+++ b/packages/tesseract-explorer/src/components/ExplorerResults.jsx
@@ -7,7 +7,7 @@ import {selectLoadingState} from "../state/loading/selectors";
 import {selectCurrentQueryItem} from "../state/queries/selectors";
 import {selectOlapCube} from "../state/selectors";
 import {selectServerState} from "../state/server/selectors";
-import {doBooleanToggle} from "../state/params/actions";
+import { LoadAllResults } from "./LoadAllResults";
 
 /**
  * @typedef OwnProps
@@ -31,8 +31,6 @@ export const ExplorerResults = props => {
   const {online: isServerOnline, url: serverUrl} = serverStatus;
   const {isDirty: isDirtyQuery, params, result} = queryItem;
   const {data, error} = result;
-
-  const fullResults = Boolean(params.booleans.full_results);
 
   const {translate: t} = useTranslation();
 
@@ -106,11 +104,11 @@ export const ExplorerResults = props => {
         {Object.keys(panels).map(key => <Tab id={key} key={key} title={t(key)} />)}
         <Tabs.Expander />
         <h2 className="token">{t("results.count_rows", {n: data.length})}</h2>
-        <h2 className="token" onClick={() => dispatch(doBooleanToggle("full_results"))}>{fullResults?"Get preview":"Get full"}</h2>
       </Tabs>
       <div className={`wrapper ${props.className}-content`}>
         <Suspense fallback={typeof transientIcon === "string" ? <Icon name={transientIcon} /> : transientIcon}>
           <CurrentComponent className="result-panel" cube={cube} params={params} result={result} />
+          <LoadAllResults />
         </Suspense>
       </div>
     </div>

--- a/packages/tesseract-explorer/src/components/LoadAllResults.jsx
+++ b/packages/tesseract-explorer/src/components/LoadAllResults.jsx
@@ -1,0 +1,56 @@
+import {Button, Callout} from "@blueprintjs/core";
+import React, {useCallback} from "react";
+import {useDispatch, useSelector} from "react-redux";
+import {useTranslation} from "../hooks/translation";
+import {useSettings} from "../hooks/settings";
+import {doSetLoadingState} from "../state/loading/actions";
+import {willExecuteQuery} from "../middleware/olapActions";
+import {doPaginationUpdate, doBooleanToggle} from "../state/params/actions";
+import {selectPaginationParams, selectBooleans} from "../state/params/selectors";
+
+/**
+ * @typedef LoadAllResultsProps
+ */
+
+/** @type {React.FC<LoadAllResultsProps>} */
+export const LoadAllResults = () => {
+  const dispatch = useDispatch();
+
+  const {translate: t} = useTranslation();
+
+  const {limit, offset} = useSelector(selectPaginationParams);
+
+  const {full_results} = useSelector(selectBooleans);
+
+  const {previewLimit} = useSettings();
+
+  const onClickLoadAllResults = useCallback(() => {
+
+    //Update limit and full results
+    dispatch(doPaginationUpdate(!full_results ? 0 : previewLimit, offset))
+    dispatch(doBooleanToggle("full_results")),
+
+    //Run the query again
+    dispatch(doSetLoadingState("REQUEST"));
+    dispatch(willExecuteQuery()).then(() => {
+      dispatch(doSetLoadingState("SUCCESS"));
+    }, error => {
+      dispatch(doSetLoadingState("FAILURE", error.message));
+    });
+
+  },[]);
+
+  return (
+    <Callout>
+      <p>
+        <strong>{full_results ? t("previewMode.title_full") : t("previewMode.title_preview")}:</strong>
+        {" "}
+        {full_results ? t("previewMode.description_full") : t("previewMode.description_preview", {limit: previewLimit})}
+        {" "}
+        <Button small={true} minimal={true} icon="database" intent="primary" className="load-all-btn" onClick={onClickLoadAllResults}>
+          {full_results ? t("previewMode.btn_get_preview") : t("previewMode.btn_get_all")}
+        </Button>
+      </p>
+    </Callout>
+  );
+};

--- a/packages/tesseract-explorer/src/components/PaginationInput.jsx
+++ b/packages/tesseract-explorer/src/components/PaginationInput.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import {useDispatch, useSelector} from "react-redux";
 import {useTranslation} from "../hooks/translation";
 import {doPaginationUpdate} from "../state/params/actions";
-import {selectPaginationParams} from "../state/params/selectors";
+import {selectPaginationParams, selectBooleans} from "../state/params/selectors";
 
 /**
  * @typedef PaginationInputProps
@@ -18,10 +18,13 @@ export const PaginationInput = () => {
 
   const {limit, offset} = useSelector(selectPaginationParams);
 
+  const {full_results} = useSelector(selectBooleans);
+
   return (
     <ButtonGroup fill={true}>
       <FormGroup label={t("params.label_pagination_limit")}>
         <NumericInput
+          disabled={!full_results}
           fill={true}
           min={0}
           onValueChange={limit => dispatch(doPaginationUpdate(limit, offset))}
@@ -33,6 +36,7 @@ export const PaginationInput = () => {
 
       <FormGroup label={t("params.label_pagination_offset")}>
         <NumericInput
+          disabled={!full_results}
           fill={true}
           min={0}
           onValueChange={offset => dispatch(doPaginationUpdate(limit, offset))}

--- a/packages/tesseract-explorer/src/enums.js
+++ b/packages/tesseract-explorer/src/enums.js
@@ -4,7 +4,8 @@ export const SERIAL_BOOLEAN = {
   NONEMPTY: 4,
   PARENTS: 8,
   SPARSE: 16,
-  EXCLUDE_DEFAULT_MEMBERS: 32
+  EXCLUDE_DEFAULT_MEMBERS: 32,
+  FULL_RESULTS: 64
 };
 
 export const Comparison = {

--- a/packages/tesseract-explorer/src/hooks/settings.js
+++ b/packages/tesseract-explorer/src/hooks/settings.js
@@ -5,11 +5,13 @@ import {createContext, createElement, useCallback, useContext, useMemo} from "re
 /**
  * @typedef SettingsContextProps
  * @property {Record<string, (d: number) => string>} formatters
+ * @property {number} previewLimit
  */
 
 /**
  * @typedef SettingsProviderProps
  * @property {Record<string, (d: number) => string>} [formatters]
+ * @property {number} previewLimit
  */
 
 /**
@@ -22,12 +24,13 @@ const {Consumer: ContextConsumer, Provider: ContextProvider} = SettingsContext;
 
 /**
  * A wrapper for the Provider, to handle the changes and API given by the hook.
- * @type {React.FC<SettingsProviderProps>}
+ * @type {React.FC<`SettingsProviderProps`>}
  */
 export const SettingsProvider = props => {
   const value = useMemo(() => ({
     formatters: props.formatters || {},
-  }), [props.formatters]);
+    previewLimit: props.previewLimit || 100
+  }), [props.formatters, props.previewLimit]);
 
   return createElement(ContextProvider, {value}, props.children);
 };

--- a/packages/tesseract-explorer/src/hooks/setup.js
+++ b/packages/tesseract-explorer/src/hooks/setup.js
@@ -17,7 +17,7 @@ import {isValidQuery} from "../utils/validation";
  * @param {OlapClient.ServerConfig} serverConfig
  * @param {string | string[]} locale
  */
-export function useSetup(serverConfig, locale) {
+export function useSetup(serverConfig, locale, previewLimit) {
   const dispatch = useDispatch();
 
   const [done, setDone] = useState(false);
@@ -37,8 +37,6 @@ export function useSetup(serverConfig, locale) {
   useEffect(() => {
     dispatch(doSetLoadingState("REQUEST"));
     setDone(false);
-
-    console.log(serverConfig);
 
     dispatch(willSetupClient(serverConfig))
       .then(() => dispatch(willReloadCubes()))
@@ -64,10 +62,10 @@ export function useSetup(serverConfig, locale) {
 
           // else, search params are a Explorer state permalink
           const locationState = parseStateFromSearchParams(searchObject);
-          query = isValidQuery(locationState) && buildQuery({params: locationState});
+          query = isValidQuery(locationState) && buildQuery({params: {...locationState, pagiLimit: previewLimit}});
         }
         else if (isValidQuery(historyState)) {
-          query = buildQuery({params: historyState});
+          query = buildQuery({params: {...historyState, pagiLimit: previewLimit}});
         }
 
         if (!query || !cubeMap.hasOwnProperty(query.params.cube)) {

--- a/packages/tesseract-explorer/src/hooks/setup.js
+++ b/packages/tesseract-explorer/src/hooks/setup.js
@@ -38,6 +38,8 @@ export function useSetup(serverConfig, locale) {
     dispatch(doSetLoadingState("REQUEST"));
     setDone(false);
 
+    console.log(serverConfig);
+
     dispatch(willSetupClient(serverConfig))
       .then(() => dispatch(willReloadCubes()))
       .then(cubeMap => {

--- a/packages/tesseract-explorer/src/hooks/translation.js
+++ b/packages/tesseract-explorer/src/hooks/translation.js
@@ -114,6 +114,14 @@ export const defaultTranslation = {
     unselected: "[Unselected]",
     none: "[None]",
   },
+  previewMode: {
+    btn_get_all: "Get all",
+    btn_get_preview: "Get preview",
+    description_full: "You are looking to all the records available. You can switch to a preview reponse for faster results clicking here:",
+    description_preview: "You are looking a preview response with just the first {{limit}} results.To get the full response click here:",
+    title_full: "All records",
+    title_preview: "Preview records"
+  },
   queries: {
     action_create: "New query",
     action_parse: "Query from URL",

--- a/packages/tesseract-explorer/src/hooks/translation.js
+++ b/packages/tesseract-explorer/src/hooks/translation.js
@@ -53,6 +53,7 @@ export const defaultTranslation = {
     label_boolean_debug: "Debug response",
     label_boolean_distinct: "Apply DISTINCT to drilldowns",
     label_boolean_exclude_default_members: "Exclude default members",
+    label_boolean_full_results: "Show full results",
     label_boolean_nonempty: "Only return non-empty data",
     label_boolean_parents: "Include parent levels",
     label_boolean_sparse: "Optimize sparse results",

--- a/packages/tesseract-explorer/src/state/server/selectors.js
+++ b/packages/tesseract-explorer/src/state/server/selectors.js
@@ -25,8 +25,8 @@ export const selectServerFormatsEnabled = createSelector(
 export const selectServerBooleansEnabled = createSelector(
   selectServerSoftware,
   software => software === TesseractDataSource.softwareName
-    ? ["debug", "exclude_default_members", "parents", "sparse"]
-    : ["debug", "distinct", "nonempty", "parents", "sparse"]
+    ? ["debug", "exclude_default_members", "parents", "sparse", "full_results",]
+    : ["debug", "distinct", "nonempty", "parents", "sparse", "full_results",]
 );
 
 export const selectOlapCubeMap = createSelector(

--- a/packages/tesseract-explorer/src/style.css
+++ b/packages/tesseract-explorer/src/style.css
@@ -94,6 +94,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-direction: column;
 }
 
 .param-popover .bp3-popover-content {

--- a/packages/tesseract-explorer/src/utils/query.js
+++ b/packages/tesseract-explorer/src/utils/query.js
@@ -8,6 +8,7 @@ import {isActiveCut, isActiveItem} from "./validation";
  * @param {TessExpl.Struct.QueryParams} params
  */
 export function applyQueryParams(query, params) {
+
   Object.entries(params.booleans).forEach(item => {
     item[1] != null && query.setOption(item[0], item[1]);
   });
@@ -74,6 +75,7 @@ export function extractQueryParams(query) {
       debug: Boolean(booleans.debug),
       distinct: Boolean(booleans.distinct),
       exclude_default_members: Boolean(booleans.exclude_default_members),
+      full_results: Boolean(booleans.full_results),
       nonempty: Boolean(booleans.nonempty),
       parents: Boolean(booleans.parents),
       sparse: Boolean(booleans.sparse)


### PR DESCRIPTION
Preview mode in tess-explorer. It is a working, we can iterate from here.

- New prop to the main component to set the max number of records retrieved in preview mode.
- New boolean setting that override and block the limit/offset control to prevent non-definitive big queries.
- Changes in layout yo show the "this is a preview" message, with the "get all" button.
- i18n messages

More info: https://github.com/tesseract-olap/tesseract-ui/issues/58