### PR TITLE
update select styles

### DIFF
--- a/packages/tesseract-explorer/src/components/Select.jsx
+++ b/packages/tesseract-explorer/src/components/Select.jsx
@@ -1,5 +1,7 @@
-import {Select} from "@mantine/core";
-import React, {useMemo} from "react";
+/* eslint-disable quotes */
+/* eslint-disable quote-props */
+import {Select, Highlight} from "@mantine/core";
+import React, {useMemo, useRef} from "react";
 import {keyBy} from "../utils/transform";
 
 /**
@@ -18,18 +20,27 @@ import {keyBy} from "../utils/transform";
 export const SelectPrimitive = props => {
   if (props.hidden) return null;
 
+  const ref = useRef(null);
+  console.log(ref.current, "current");
   return (
     <Select
+      ref={ref}
       data={props.items}
       disabled={props.loading || props.disabled}
       label={props.label}
       onChange={props.onItemSelect}
       searchable={props.searchable ?? props.items.length > 6}
       value={props.selectedItem}
+      data-highlight={"Nacional"}
+      styles={theme => ({
+        input: {
+          "&:focus": {color: "highlight"}
+        },
+        '& [data-highlight="Nacional"]': {backgroundColor: theme.colors.grape[4]}
+      })}
     />
   );
-}
-  ;
+};
 
 SelectPrimitive.defaultProps = {
   disabled: false,
@@ -58,7 +69,6 @@ SelectPrimitive.defaultProps = {
  * @type {React.FC<SelectObjectProps<any>>}
  */
 export const SelectObject = props => {
-
   const [itemList, itemMap] = useMemo(() => {
     const getKey = props.getKey || props.getLabel;
     const list = props.items.map(item => ({

--- a/packages/tesseract-explorer/src/components/Select.jsx
+++ b/packages/tesseract-explorer/src/components/Select.jsx
@@ -32,9 +32,8 @@ export const SelectPrimitive = props => {
       data-highlight={"Nacional"}
       styles={theme => ({
         input: {
-          "&:focus": {color: "highlight"}
-        },
-        '& [data-highlight="Nacional"]': {backgroundColor: theme.colors.grape[4]}
+          "&:focus": {color: theme.colors.highlight}
+        }
       })}
     />
   );

--- a/packages/tesseract-explorer/src/components/Select.jsx
+++ b/packages/tesseract-explorer/src/components/Select.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable quotes */
 /* eslint-disable quote-props */
-import {Select, Highlight} from "@mantine/core";
-import React, {useMemo, useRef} from "react";
+import {Select} from "@mantine/core";
+import React, {useMemo} from "react";
 import {keyBy} from "../utils/transform";
 
 /**
@@ -20,8 +20,6 @@ import {keyBy} from "../utils/transform";
 export const SelectPrimitive = props => {
   if (props.hidden) return null;
 
-  const ref = useRef(null);
-  console.log(ref.current, "current");
   return (
     <Select
       ref={ref}

--- a/packages/tesseract-explorer/src/components/Select.jsx
+++ b/packages/tesseract-explorer/src/components/Select.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable quotes */
 /* eslint-disable quote-props */
-import {Select} from "@mantine/core";
 import React, {useMemo} from "react";
+import {Select} from "@mantine/core";
 import {keyBy} from "../utils/transform";
 
 /**
@@ -22,19 +22,14 @@ export const SelectPrimitive = props => {
 
   return (
     <Select
-      ref={ref}
       data={props.items}
       disabled={props.loading || props.disabled}
       label={props.label}
       onChange={props.onItemSelect}
       searchable={props.searchable ?? props.items.length > 6}
       value={props.selectedItem}
-      data-highlight={"Nacional"}
-      styles={theme => ({
-        input: {
-          "&:focus": {color: theme.colors.highlight}
-        }
-      })}
+      onFocus={event => event.target.select()}
+      onClick={event => event.target.select()}
     />
   );
 };


### PR DESCRIPTION
Hey, @davelandry.
Now when the user clicks the select field, the text will change the color & use `theme.color.highlight` defined in the Mantine Theme Provider. So, this way we can override it in any app.

See video with implementation.

https://github.com/tesseract-olap/tesseract-ui/assets/2966438/ab88a539-b121-43c4-8c3b-e4e2b03d5b55

