### PR TITLE
adds default value for "action_copy_done" translation string

### DIFF
--- a/packages/tesseract-explorer/src/hooks/translation.ts
+++ b/packages/tesseract-explorer/src/hooks/translation.ts
@@ -3,6 +3,7 @@ import {translationFactory} from "@datawheel/use-translation";
 
 export const defaultTranslation = {
   action_copy: "Copy",
+  action_copy_done: "Copied",
   action_download: "Download",
   action_open: "Open",
   action_reload: "Reload",


### PR DESCRIPTION
There is a missing default, which results in the string being seen after the API url is successfully copied to user's clipboard: https://github.com/tesseract-olap/tesseract-ui/blob/master/packages/tesseract-explorer/src/components/DebugView.tsx#L71